### PR TITLE
022 was identified as a duplicate of 003 et al. Remove it

### DIFF
--- a/WaltonSustainabilityCentre-Requirements.txt
+++ b/WaltonSustainabilityCentre-Requirements.txt
@@ -116,13 +116,6 @@ Type: Functional.
 Rationale:  As the membership roll evolves through time, a mechanism is needed to remove inactive members for a variety of reasons: on request, inactivity, etc.
 Originator: Marion and Justin.
 Comments: Added by Tim Holmes-Mitra.  Although this requirement was not explicitly stated during interviews, is an implicit and necessary part of membership management.
-
-REQ-ID: 022
-Description: The product should allow the quick access of a member's information.
-Type: Functional.
-Rationale: As bookings are being taken the user of the system should be able to fetch a member information as fast as possible.   
-Originator: Marion.
-Comments: Added by Ken Wilson. During the interview Marion stated the following, "when taking bookings for workshops over the phone we should be able to access membership records to get the details of the attendee". This functional requirement covers that use-case.
  
 REQ-ID: 023
 Description: The product should all for daily generation of reports. 


### PR DESCRIPTION
There was some comment on the [forum](https://learn2.open.ac.uk/mod/forumng/discuss.php?d=2098450&expand=1&timeread=1489137525) that no consensus was reached, but I believe it was:

```
Req 022 - Use of the word 'quick' makes this a non-functional requirement. If the word quick is removed then it becomes a duplicate of 014. (REMOVE)
```

```
I agree with your assessment of REQ-ID: 022.^M
```

```
Req-022 – This is written as a NFR.  If the point of the requirement is being able to search for a member then it is a duplication of Req-003, if it is about speed so that this can be done while on a telephone with a member that is then an NFR.
```

```
22	Remove as duplicate of 14
```

I've therefore removed 022.